### PR TITLE
fix: correct crypto API for note decryption

### DIFF
--- a/src/helpers/util.helpers.js
+++ b/src/helpers/util.helpers.js
@@ -18,8 +18,12 @@ module.exports = {
   },
 
   decrypt(text, password) {
-    const decipher = crypto.createCipheriv(process.env.ALGORITHM, (password + process.env.SECRET).substr(0, 32), process.env.IV)
-    let dec = decipher.update(text, 'hex', 'utf8')
+    const decipher = crypto.createDecipheriv(
+      process.env.ALGORITHM,
+      (password + process.env.SECRET).substr(0, 32),
+      process.env.IV
+    );
+    let dec = decipher.update(text, 'hex', 'utf8');
     dec += decipher.final('utf8');
     return dec;
   },


### PR DESCRIPTION
## Summary
- ensure decrypt helper uses `crypto.createDecipheriv`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node -e "process.env.ALGORITHM='aes-256-cbc';process.env.SECRET='12345678901234567890123456789012';process.env.IV='1234567890123456';const util=require('./src/helpers/util.helpers');const enc=util.encrypt('hello','key');console.log('dec',util.decrypt(enc,'key'));"`


------
https://chatgpt.com/codex/tasks/task_e_6895c94a061c832284c74e0d37e78fd5